### PR TITLE
Improve 'd-stan' function

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,9 @@ Runs PHPStan analyze.
 d-phpstan .
 ```
 
+> [!NOTE]
+> If the local `phpstan.neon` file is not found, a contrib version of the file 
+> from Drupal CI will be downloaded to a temporary directory.
+
 ## License
 GNU General Public License, version 2.

--- a/drupalrc
+++ b/drupalrc
@@ -423,8 +423,8 @@ function d-phpstan {
     CONFIGURATION="--configuration=phpstan.neon"
   else
     if [[ ! -f /tmp/drupalrc.phpstan.neon ]]; then
-      echo "Executing curl -output /tmp/drupalrc.phpstan.neon https://git.drupalcode.org/project/gitlab_templates/-/raw/main/assets/phpstan.neon"
-      curl -output /tmp/drupalrc.phpstan.neon https://git.drupalcode.org/project/gitlab_templates/-/raw/main/assets/phpstan.neon
+      echo "Executing curl --output /tmp/drupalrc.phpstan.neon https://git.drupalcode.org/project/gitlab_templates/-/raw/main/assets/phpstan.neon"
+      curl --output /tmp/drupalrc.phpstan.neon https://git.drupalcode.org/project/gitlab_templates/-/raw/main/assets/phpstan.neon
     fi
     CONFIGURATION="--configuration=/tmp/drupalrc.phpstan.neon"
   fi

--- a/drupalrc
+++ b/drupalrc
@@ -422,11 +422,11 @@ function d-phpstan {
   if [[ -f phpstan.neon ]]; then
     CONFIGURATION="--configuration=phpstan.neon"
   else
-    if [[ ! -f /tmp/drupalrc/phpstan.neon ]]; then
-      echo "Executing curl -O --create-dirs --output-dir /tmp/drupalrc https://git.drupalcode.org/project/gitlab_templates/-/raw/main/assets/phpstan.neon"
-      curl -O --create-dirs --output-dir /tmp/drupalrc https://git.drupalcode.org/project/gitlab_templates/-/raw/main/assets/phpstan.neon
+    if [[ ! -f /tmp/drupalrc.phpstan.neon ]]; then
+      echo "Executing curl -output /tmp/drupalrc.phpstan.neon https://git.drupalcode.org/project/gitlab_templates/-/raw/main/assets/phpstan.neon"
+      curl -output /tmp/drupalrc.phpstan.neon https://git.drupalcode.org/project/gitlab_templates/-/raw/main/assets/phpstan.neon
     fi
-    CONFIGURATION="--configuration=/tmp/drupalrc/phpstan.neon"
+    CONFIGURATION="--configuration=/tmp/drupalrc.phpstan.neon"
   fi
 
   "$PHPSTAN" analyze "$CONFIGURATION" "$@"

--- a/drupalrc
+++ b/drupalrc
@@ -418,7 +418,18 @@ function d-phpstan {
     return 1
   fi
 
-  "$PHPSTAN" analyze -c "$DRUPAL_ROOT"/core/phpstan.neon.dist "$@"
+  local CONFIGURATION
+  if [[ -f phpstan.neon ]]; then
+    CONFIGURATION="--configuration=phpstan.neon"
+  else
+    if [[ ! -f /tmp/drupalrc/phpstan.neon ]]; then
+      echo "Executing curl -O --create-dirs --output-dir /tmp/drupalrc https://git.drupalcode.org/project/gitlab_templates/-/raw/main/assets/phpstan.neon"
+      curl -O --create-dirs --output-dir /tmp/drupalrc https://git.drupalcode.org/project/gitlab_templates/-/raw/main/assets/phpstan.neon
+    fi
+    CONFIGURATION="--configuration=/tmp/drupalrc/phpstan.neon"
+  fi
+
+  "$PHPSTAN" analyze "$CONFIGURATION" "$@"
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
- Checks for `phpstan.neon` and uses it if it is found.
- If a local `phpstan.neon` file cannot be found, it downloads the contrib version of the file from Drupal CI and saves it in a temporary directory. The downloaded file is then used.